### PR TITLE
Fix encoding issue.

### DIFF
--- a/src/Private/GitFunctions.ps1
+++ b/src/Private/GitFunctions.ps1
@@ -114,7 +114,7 @@ function Get-GitColorAndIcon{
     }
 
     if($hideIcons){
-        $gitGlyph = "√";
+        $gitGlyph = "$([char]0x221a)";
     }else{
         $gitGlyph = $glyphs["nf-fa-check"]
     }


### PR DESCRIPTION
My system's encoding is GB2312, not UTF-8. However, I downloaded the files as UTF-8 encoding. When importing the module, the symbol "√" causes unexpected token issue.

This can be solved by change the encoding of the file to GB2312, but I think use the symbol's code point would be a general solution.
